### PR TITLE
Fix XamChat repo link

### DIFF
--- a/SignalR- Real-time Communication for Xamarin/README.md
+++ b/SignalR- Real-time Communication for Xamarin/README.md
@@ -7,7 +7,7 @@ Stop polling and enable bi-directional communication between your server and mob
 
 * [Install Visual Studio tools for Xamarin](https://docs.microsoft.com/visualstudio/cross-platform/setup-and-install)
 * [App Code - Simple SignalR Push](https://github.com/jamesmontemagno/app-SimpleSignalR)
-* [App Code - XamChat](github.com/jamesmontemagno/xamchat)
+* [App Code - XamChat](https://github.com/jamesmontemagno/xamchat)
 
 ## Demo Walkthrough
 


### PR DESCRIPTION
Without the protocol, GitHub was trying to make this a relative URL, resulting in a 404. The sample repo link above it was already good-to-go.